### PR TITLE
feat: support for hotfix branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,15 +191,16 @@ _Example3 (with feature message):_
 
 You can configure the action with various inputs, a list of which has been provided below:
 
-| Name             | Description                                                                                     | Default Value |
-|------------------|-------------------------------------------------------------------------------------------------|---------------|
-| tool-version     | The version of the tool to run                                                                  | latest        |
-| release-branch   | The name of the master/main branch                                                              | master        |
-| dev-branch       | The name of the development branch                                                              | dev           |
-| year_switch_mode | Specifies when to switch to a new year. Possible values:<br/>  - Always - switches to a new year for all changes<br/>  - OnMinor - switches to a new year only for minor changes, not for patch changes | Always        |
-| minor-identifier | The string used to identify a minor release (wrap with '/' to match using a regular expression) | feature:      |
-| prefix           | The prefix used for the version name                                                            |               |
-| log-paths        | The paths used to calculate changes (comma-separated)                                           |               |
+| Name                  | Description                                                                                                                                                                                             | Default Value |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| tool-version          | The version of the tool to run                                                                                                                                                                          | latest        |
+| release-branch        | The name of the master/main branch                                                                                                                                                                      | master        |
+| dev-branch            | The name of the development branch                                                                                                                                                                      | dev           |
+| hotfix-branch-pattern | The regex pattern for all hotfix branches                                                                                                                                                               | dev           |
+| year_switch_mode      | Specifies when to switch to a new year. Possible values:<br/>  - Always - switches to a new year for all changes<br/>  - OnMinor - switches to a new year only for minor changes, not for patch changes | Always        |
+| minor-identifier      | The string used to identify a minor release (wrap with '/' to match using a regular expression)                                                                                                         | feature:      |
+| prefix                | The prefix used for the version name                                                                                                                                                                    |               |
+| log-paths             | The paths used to calculate changes (comma-separated)                                                                                                                                                   |               |
 
 ## Requirements
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   color: 'gray-dark'
 inputs:
   tool-version:
-    description: 'The version of the tool to be ran'
+    description: 'The version of the tool to be run'
     required: true
     default: latest
   release-branch:
@@ -17,6 +17,10 @@ inputs:
     description: 'The name of the dev branch'
     required: true
     default: dev
+  hotfix-branch-pattern:
+    description: 'The regex pattern for hotfix branches'
+    required: true
+    default: 'release_.*'
   year_switch_mode:
     description: |
       Specifies when to switch to a new year. 
@@ -65,6 +69,7 @@ runs:
             --previous-version \
             --release-branch "${{ inputs.release-branch }}" \
             --dev-branch "${{ inputs.dev-branch }}" \
+            --hotfix-branch-pattern "${{ inputs.hotfix-branch-pattern }}" \
             --year-switch-mode "${{ inputs.year_switch_mode }}" \
             --minor-identifier="${{ inputs.minor-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")
@@ -79,6 +84,7 @@ runs:
         export VERSION=$(semantic-calendar-version \
             --release-branch "${{ inputs.release-branch }}" \
             --dev-branch "${{ inputs.dev-branch }}" \
+            --hotfix-branch-pattern "${{ inputs.hotfix-branch-pattern }}" \
             --year-switch-mode "${{ inputs.year_switch_mode }}" \
             --minor-identifier="${{ inputs.minor-identifier }}" \
             --version-prefix "${{ inputs.prefix }}")

--- a/spec/semantic-calendar-version-spec.cr
+++ b/spec/semantic-calendar-version-spec.cr
@@ -10,7 +10,7 @@ describe SemanticCalendarVersion do
     tmp = InTmp.new
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
       current_year = Time.local.year
 
       tmp.exec %(git init)
@@ -61,7 +61,7 @@ describe SemanticCalendarVersion do
       tmp.exec %(git checkout -b my-fancy.branch)
       tmp.exec %(git commit --no-gpg-sign --allow-empty -m "2")
 
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       hash = git.current_commit_hash
 
@@ -73,6 +73,31 @@ describe SemanticCalendarVersion do
     end
   end
 
+  it "should get the correct version hotfix branch" do
+      tmp = InTmp.new
+      current_year = Time.local.year
+
+      begin
+        tmp.exec %(git init)
+        tmp.exec %(git checkout -b master)
+        tmp.exec %(git commit --no-gpg-sign --allow-empty -m "1")
+        tmp.exec %(git tag "#{current_year}.1.0")
+
+        tmp.exec %(git checkout -b release_2025_1_0)
+        tmp.exec %(git commit --no-gpg-sign --allow-empty -m "2")
+
+        git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+
+        hash = git.current_commit_hash
+
+        version = git.get_new_version
+
+        version.should eq("#{current_year}.1.1")
+      ensure
+        tmp.cleanup
+      end
+    end
+
   it "should properly bump the version using regex" do
     tmp = InTmp.new
     current_year = Time.local.year
@@ -83,7 +108,7 @@ describe SemanticCalendarVersion do
       tmp.exec %(git commit --no-gpg-sign --allow-empty -m "1")
       tmp.exec %(git tag "#{current_year}.1.0")
 
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "/feat(?:\\([^)]+\\))?:/", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "/feat(?:\\([^)]+\\))?:/", tmp.@tmpdir)
 
       tmp.exec %(git commit --no-gpg-sign --allow-empty -m "feat: 2")
 
@@ -121,7 +146,7 @@ describe SemanticCalendarVersion do
 
       tmp.exec %(git checkout -b dev)
 
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git commit --no-gpg-sign --allow-empty -m "XYZ in new year")
 
@@ -156,7 +181,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -205,7 +230,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -235,7 +260,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -254,7 +279,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -279,7 +304,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -330,7 +355,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -361,7 +386,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -394,7 +419,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -423,7 +448,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -443,7 +468,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::OnMinor, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::OnMinor, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -463,7 +488,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::OnMinor, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::OnMinor, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -491,7 +516,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -511,7 +536,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -529,7 +554,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -550,7 +575,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -570,7 +595,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -589,7 +614,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -608,7 +633,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -630,7 +655,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir2/")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir2/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -660,7 +685,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir1/ dir3/")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir1/ dir3/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -700,7 +725,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir2/ dir3/")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir2/ dir3/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -739,7 +764,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir1/")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "", "dir1/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -764,7 +789,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "dir2-", "dir2/ dir3/")
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "dir2-", "dir2/ dir3/")
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b master)
@@ -804,7 +829,7 @@ describe SemanticCalendarVersion do
     current_year = Time.local.year
 
     begin
-      git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+      git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
       tmp.exec %(git init)
       tmp.exec %(git checkout -b very-very-very-very-long-branch-name-that-excedes-k8s-limits)
@@ -824,7 +849,7 @@ it "get previous version - first commit" do
   tmp = InTmp.new
 
   begin
-    git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
+    git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir)
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -842,7 +867,7 @@ it "get previous version - first commit w/ prefix" do
   tmp = InTmp.new
 
   begin
-    git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
+    git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)
@@ -860,7 +885,7 @@ it "get previous version - pre-tagged" do
   tmp = InTmp.new
 
   begin
-    git = SemanticCalendarVersion::Git.new("dev", "master", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
+    git = SemanticCalendarVersion::Git.new("dev", "master", "release_.*", SemanticCalendarVersion::YearSwitchMode::Always, "feat:", tmp.@tmpdir, "v")
 
     tmp.exec %(git init)
     tmp.exec %(git checkout -b master)

--- a/src/main.cr
+++ b/src/main.cr
@@ -7,6 +7,7 @@ require "./semantic-calendar-version"
 previous_version = false
 dev_branch = "dev"
 release_branch = "master"
+hotfix_branch = "release_.*"
 year_switch_mode = "Always"
 minor_identifier = "feature:"
 prefix = ""
@@ -19,6 +20,7 @@ OptionParser.parse do |parser|
   parser.on("-f FOLDER", "--folder=FOLDER", "Execute the command in the defined folder") { |f| folder = f }
   parser.on("-b BRANCH", "--dev-branch=BRANCH", "Specifies the development branch") { |branch| dev_branch = branch }
   parser.on("-r BRANCH", "--release-branch=BRANCH", "Specifies the release branch") { |branch| release_branch = branch }
+  parser.on("-h BRANCH_PATTERN", "--hotfix-branch-pattern=BRANCH", "Specifies the release branch Regex pattern") { |branch| hotfix_branch = branch }
   parser.on("--year-switch-mode=MODE", "Specifies when to switch to a new year") { |mode| year_switch_mode = mode }
   parser.on("--minor-identifier=IDENTIFIER",
     "Specifies the string or regex to identify a minor release commit with") { |identifier| minor_identifier = identifier }
@@ -33,7 +35,7 @@ OptionParser.parse do |parser|
   end
 end
 
-git = SemanticCalendarVersion::Git.new(dev_branch, release_branch, SemanticCalendarVersion::YearSwitchMode.parse(year_switch_mode), minor_identifier, folder, prefix, log_paths)
+git = SemanticCalendarVersion::Git.new(dev_branch, release_branch, hotfix_branch, SemanticCalendarVersion::YearSwitchMode.parse(year_switch_mode), minor_identifier, folder, prefix, log_paths)
 
 if previous_version
   puts "#{git.get_previous_version}"

--- a/src/semantic-calendar-version.cr
+++ b/src/semantic-calendar-version.cr
@@ -18,7 +18,7 @@ module SemanticCalendarVersion
   end
 
   class Git
-    def initialize(@dev_branch : String, @release_branch : String, @year_switch_mode : YearSwitchMode, @minor_identifier : String,
+    def initialize(@dev_branch : String, @release_branch : String, @hotfix_branch : String, @year_switch_mode : YearSwitchMode, @minor_identifier : String,
                    @folder = FileUtils.pwd, @prefix : String = "", @log_paths : String = "")
       @minor_id_is_regex = false
       if match = /\/(.*)\//.match(@minor_identifier)
@@ -197,7 +197,7 @@ module SemanticCalendarVersion
 
       cb = current_branch_or_tag
 
-      if cb == @release_branch
+    if cb == @release_branch || /#{@hotfix_branch}/.match(cb)
         #
       elsif cb == @dev_branch
         prerelease = [DEV_BRANCH_SUFFIX, commits_distance(previous_tag), current_commit_hash()] of String | Int32


### PR DESCRIPTION
This patch introduces new input parameter `hotfix-branch-pattern` that represents a Regex pattern matching all hotfix branches that should produce simple calendar versioning versions for ad-hoc releasing hotfixes of old versions.